### PR TITLE
 # EDIT - RSA Sign with Buffered data

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -149,11 +149,41 @@ const protobuf_msg_serializer = function(PROTO_PATH, msg_type_name, packed_msg){
 	return serialized_msg;
 };
 
+const txToBuffer = function(tx){
+	let length = 0;
+	let bf_list = [];
+
+	length = pushBufferList(bf_list, length, Buffer.from(tx.txid, 'base64'));
+	length = pushBufferList(bf_list, length, getBufferedTimestamp(tx.time));
+	length = pushBufferList(bf_list, length, Buffer.from(tx.rID, 'base64'));
+	length = pushBufferList(bf_list, length, Buffer.from(tx.type));
+	for (let i=0; i<tx.content.length; i++){
+		length = pushBufferList(bf_list, length, Buffer.from(tx.content[i]));
+	}
+
+	const bf_combined = Buffer.concat(bf_list, length);
+	return bf_combined;
+}
+
+const getBufferedTimestamp = function(str_timestamp){
+	const bf_time = Buffer.allocUnsafe(8);
+	bf_time.writeInt32BE(0x0, 0);
+	bf_time.writeInt32BE(parseInt(str_timestamp, 10), 4);
+	return bf_time;
+}
+
+const pushBufferList = function(bf_list, length, single_buffer){
+	bf_list.push(single_buffer);
+	length += single_buffer.length;
+	return length;
+}
+
 const self = module.exports = {
 	pack : pack,
 	unpack : unpack,
 	zipIt : zipIt,
 	unzipIt : unzipIt,
 	protobuf_msg_serializer : protobuf_msg_serializer,
-	MSG_TYPE : MSG_TYPE
+	MSG_TYPE : MSG_TYPE,
+	txToBuffer : txToBuffer
 };

--- a/src/mytools.js
+++ b/src/mytools.js
@@ -108,6 +108,7 @@ const publicKey = '-----BEGIN PUBLIC KEY-----\n'+
 't4KUcQ1TaazB8TzhqwIDAQAB\n'+
 '-----END PUBLIC KEY-----';
 
+// check out this https://nodejs.org/api/crypto.html#crypto_class_sign
 const signRSA = function(data){
 	var signer = crypto.createSign('sha256');
 	signer.update(data);

--- a/src/tx_generator.js
+++ b/src/tx_generator.js
@@ -79,20 +79,22 @@ function tx_send(p_num) {
 	setTimeout(tx_send, 2000);
 }
 
-
 function genTx(p_num){
     ++txid;
 
     let rID = tools.get64Hash("TX GENERATOR # " + p_num );
     let ts = tools.getTimestamp();
 
-    var tx = new Object();
+    var tx = {};
 	tx.txid = tools.getSHA256(rID + txid);
     tx.time = ts;
     tx.rID = rID;
     tx.type = "digests";
     tx.content = genContents(rID, ts);
-    tx.rSig = tools.signRSA(JSON.stringify(tx.content));
+
+    let bf_tx = common.txToBuffer(tx);
+    let rSig = tools.signRSA(bf_tx);
+    tx.rSig = rSig;
 
 	return tx;
 }


### PR DESCRIPTION
- 설계서에 따르면 서명에 사용되는 데이터는 byte 수준으로 관리해야함
- 기존 RSASign은 대강 포맷만 맞춤
- 설계서와 일치하도록 서명 데이터를 byte format으로 변경