### PR TITLE
 # FIX - SEID doesn't match to spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm install
 
 ### tx_generator 실행
 ```
-npm run txgen address port n(tx emulator number, optional)
+npm run txgen address port n(se emulator number, default: 1)
 ```
 - tx generator는 SE의 트랜잭션을 에뮬레이션합니다.
 - tx generator의 RSA 서명키는 하드코딩되어있습니다.

--- a/src/common.js
+++ b/src/common.js
@@ -149,14 +149,14 @@ const protobuf_msg_serializer = function(PROTO_PATH, msg_type_name, packed_msg){
 	return serialized_msg;
 };
 
-const txToBuffer = function(tx){
+const buildSigBuffer = function(tx){
 	let length = 0;
 	let bf_list = [];
 
-	length = pushBufferList(bf_list, length, Buffer.from(tx.txid, 'base64'));
+	length = pushBufferList(bf_list, length, Buffer.from(tx.txid, 'base64')); // b64 to buf
 	length = pushBufferList(bf_list, length, getBufferedTimestamp(tx.time));
-	length = pushBufferList(bf_list, length, Buffer.from(tx.rID));
-	length = pushBufferList(bf_list, length, Buffer.from(tx.type));
+	length = pushBufferList(bf_list, length, Buffer.from(tx.rID));  // str to buf
+	length = pushBufferList(bf_list, length, Buffer.from(tx.type)); // str to buf 
 	for (let i=0; i<tx.content.length; i++){
 		length = pushBufferList(bf_list, length, Buffer.from(tx.content[i]));
 	}
@@ -185,5 +185,5 @@ const self = module.exports = {
 	unzipIt : unzipIt,
 	protobuf_msg_serializer : protobuf_msg_serializer,
 	MSG_TYPE : MSG_TYPE,
-	txToBuffer : txToBuffer
+	buildSigBuffer : buildSigBuffer
 };

--- a/src/common.js
+++ b/src/common.js
@@ -126,7 +126,7 @@ const headerChainId = function (id){
 };
 
 const headerSender = function (sender_id){
-	if (sender_id.length > 16) return null;
+	if (sender_id.length > 8) return null;
 
 	return new Buffer.from(sender_id, 'hex');
 };
@@ -155,7 +155,7 @@ const txToBuffer = function(tx){
 
 	length = pushBufferList(bf_list, length, Buffer.from(tx.txid, 'base64'));
 	length = pushBufferList(bf_list, length, getBufferedTimestamp(tx.time));
-	length = pushBufferList(bf_list, length, Buffer.from(tx.rID, 'base64'));
+	length = pushBufferList(bf_list, length, Buffer.from(tx.rID));
 	length = pushBufferList(bf_list, length, Buffer.from(tx.type));
 	for (let i=0; i<tx.content.length; i++){
 		length = pushBufferList(bf_list, length, Buffer.from(tx.content[i]));

--- a/src/mytools.js
+++ b/src/mytools.js
@@ -84,6 +84,10 @@ var getRandomBetween = function(min, max){
 	return Math.floor(Math.random() * (max - min + 1)) + min;
 };
 
+var getSEID = function(id){
+	return "GENTSE-" + id ;
+};
+
 // I got this from https://stackoverflow.com/questions/25006460/cant-verify-signature-witn-node-js-crypto-using-key-pairs
 const privateKey = '-----BEGIN PRIVATE KEY-----\n\
 MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDMBQUNCNMLLsb9\
@@ -158,7 +162,7 @@ const argvParser = function(process_argv){
 		obj.n = process_argv[4];
 
 		case 4:
-		obj.n = (obj.n)? obj.n : 0;
+		obj.n = (obj.n)? obj.n : 1;
         obj.addr = process_argv[2];
 		obj.port = process_argv[3];
 		obj.ok = true;
@@ -199,7 +203,7 @@ const printHowToUse = function(){
 	console.log ("- [script_name] should be one of these [merger, signer, tx_generator]");
 	console.log ("- [ip_or_addr] should be a valid form of IP or URL ");
 	console.log ("- [port] should be a number less than 65535");
-	console.log ("- [emulator_id](Optional) should be a number");
+	console.log ("- [se_id] should be a number (default: 1)");
 };
 
 var self = module.exports = {
@@ -212,5 +216,6 @@ var self = module.exports = {
 	signRSA : signRSA,
 	getTimestamp : getTimestamp,
 	argvParser : argvParser,
-	printHowToUse: printHowToUse
+	printHowToUse: printHowToUse,
+	getSEID : getSEID
 };

--- a/src/tx_generator.js
+++ b/src/tx_generator.js
@@ -40,7 +40,7 @@ var TXPackageDefinition = protoLoader.loadSync(
 
 var proto_tx = grpc.loadPackageDefinition(TXPackageDefinition).grpc_se;
 var client = null;
-var txid = 0;
+var n_tx = 0;
 
 /**
  * Starts tx_generator
@@ -67,7 +67,7 @@ main();
  */
 function tx_send(se_num) {
     var tx = genTx(se_num);
-    logger.info(" req  #" + txid); 
+    logger.info(" req  #" + n_tx);
     logger.info(JSON.stringify(tx));
 
     // SEID: txbody에는 base64인코딩으로, 헤더에는 64bit바이너리로 사용
@@ -77,32 +77,34 @@ function tx_send(se_num) {
         logger.debug("I got this res: " + JSON.stringify(res));
     });
 
-	setTimeout(function(){tx_send(se_num);}, 2000);
+	setTimeout(function(){tx_send(se_num);}, 100);
 }
 
 function genTx(se_num){
-    ++txid;
+    ++n_tx;
 
     let rID = tools.getSEID(se_num);
     let ts = tools.getTimestamp();
+    let cID = "Client #" + n_tx; // random client ID
 
     var tx = {};
-	tx.txid = tools.getSHA256(rID + txid);
+    tx.txid = tools.getSHA256(rID + n_tx);
     tx.time = ts;
     tx.rID = rID;
     tx.type = "DIGESTS";
-    tx.content = genContents(rID, ts);
+    tx.content = genContents(cID, ts);
 
-    let bf_tx = common.txToBuffer(tx);
+    let bf_tx = common.buildSigBuffer(tx);
     let rSig = tools.signRSA(bf_tx);
 
+    //string rID to base64
     tx.rID = Buffer.from(rID).toString('base64');
     tx.rSig = rSig;
 
 	return tx;
 }
 
-function genContents(rID, ts){
+function genContents(cID, ts){
     let contents = [];
     let n = tools.getRandomBetween(0,10);
     let item;
@@ -112,21 +114,21 @@ function genContents(rID, ts){
         case 3:
         case 10:
         for(i=0; i<n; i++){
-            addSingleContent(contents, rID, ts, i);
+            addSingleContent(contents, cID, ts, i);
         }
         break;
         default:
-            addSingleContent(contents, rID, ts, 0);
+            addSingleContent(contents, cID, ts, 0);
         break;
     }
 
     return contents;
 }
 
-function addSingleContent(contents, rID, ts, n){
-    let data = "Data #" + txid + ((n==0)? "" : "-" + n);
-    let dataID = tools.get64Hash(data + txid);
-    contents.push(rID);
+function addSingleContent(contents, cID, ts, n){
+    let data = "Data #" + n_tx + ((n==0)? "" : "-" + n);
+    let dataID = tools.get64Hash(data + n_tx);
+    contents.push(cID);
     contents.push(ts);
     contents.push(dataID);
     contents.push(data);


### PR DESCRIPTION
 ### SEID 명세서 불일치 문제
(기존)
- SEID를 랜덤하게 생성함.
- tx generator를 제작할 당시에 id필드만 있었고, 명세가 없었음

(현재)
- 명세에 따라 GENTSE-N을 갖도록 수정
- getSEID 함수 생성
- gen_tx가 올바른 SEID를 가져오도록 함
- tx.type: digests -> DIGESTS
- tx.rID는 base64로 인코딩

 ### 기타
- tx_send 함수의 매개변수명 변경(p_num -> se_num)
- tx_send 재실행시 매개변수로 se_num을 보내지 않는 버그 수정
- 기본 SE 번호: 0 -> 1
- README 및 howtouse 함수 출력내용 수정